### PR TITLE
676: Ensure request object has exp and nbf claims

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -37,6 +37,7 @@
     "hashSalt": "gnsdjcwx1a1acia62voroervtgq0",
     "moduleMessageEnabledInPasswordGrant": false,
     "tlsCertificateBoundAccessTokensEnabled": true,
+    "nbfClaimRequiredInRequestObject": true,
     "displayNameAttribute": "cn",
     "supportedScopes": [
       "openid",
@@ -49,6 +50,7 @@
       "code|org.forgerock.oauth2.core.AuthorizationCodeResponseTypeHandler",
       "id_token|org.forgerock.openidconnect.IdTokenResponseTypeHandler"
     ],
+    "expClaimRequiredInRequestObject": true,
     "tokenCompressionEnabled": false,
     "allowedAudienceValues": [
       "https://{{.Hosts.IgFQDN}}:443/am/oauth2/realms/root/realms/alpha/access_token"

--- a/pkg/securebanking/oauth2.go
+++ b/pkg/securebanking/oauth2.go
@@ -281,6 +281,8 @@ func UpdateOAuth2Provider(claimsScriptID string) {
 		return
 	}
 
+	zap.S().Infof("Pushing the following config %+v", oauth2Provider)
+
 	oauth2Provider.PluginsConfig.OidcClaimsScript = claimsScriptID
 	zap.S().Infow("UpdateOAuth2Provider() Updating OAuth2 provider", "claimScriptId", claimsScriptID)
 	path := "/am/json/" + common.Config.Identity.AmRealm + "/realm-config/services/oauth-oidc"

--- a/pkg/types/oauth2models.go
+++ b/pkg/types/oauth2models.go
@@ -47,9 +47,11 @@ type (
 		HashSalt                                string        `json:"hashSalt"`
 		ModuleMessageEnabledInPasswordGrant     bool          `json:"moduleMessageEnabledInPasswordGrant"`
 		TLSCertificateBoundAccessTokensEnabled  bool          `json:"tlsCertificateBoundAccessTokensEnabled"`
+		NbfClaimRequiredInRequestObject         bool          `json:"nbfClaimRequiredInRequestObject"`
 		DisplayNameAttribute                    string        `json:"displayNameAttribute"`
 		SupportedScopes                         []string      `json:"supportedScopes"`
 		ResponseTypeClasses                     []string      `json:"responseTypeClasses"`
+		ExpClaimRequiredInRequestObject         bool          `json:"expClaimRequiredInRequestObject"`
 		TokenCompressionEnabled                 bool          `json:"tokenCompressionEnabled"`
 		AllowedAudienceValues                   []interface{} `json:"allowedAudienceValues"`
 		TLSCertificateRevocationCheckingEnabled bool          `json:"tlsCertificateRevocationCheckingEnabled"`


### PR DESCRIPTION
This is required to pass the FAPI1-Advanced conformance tests

Issue: https://github.com/secureapigateway/secureapigateway/issues/676