### PR TITLE
676: Add AM OAuth2Provider config

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -38,6 +38,7 @@
     "moduleMessageEnabledInPasswordGrant": false,
     "tlsCertificateBoundAccessTokensEnabled": true,
     "nbfClaimRequiredInRequestObject": true,
+    "maxDifferenceBetweenRequestObjectNbfAndExp": 60,
     "displayNameAttribute": "cn",
     "supportedScopes": [
       "openid",

--- a/pkg/types/oauth2models.go
+++ b/pkg/types/oauth2models.go
@@ -35,26 +35,27 @@ type (
 	}
 
 	AdvancedOAuth2Config struct {
-		TLSClientCertificateHeaderFormat        string        `json:"tlsClientCertificateHeaderFormat"`
-		SupportedSubjectTypes                   []string      `json:"supportedSubjectTypes"`
-		DefaultScopes                           []interface{} `json:"defaultScopes"`
-		MacaroonTokenFormat                     string        `json:"macaroonTokenFormat"`
-		CodeVerifierEnforced                    string        `json:"codeVerifierEnforced"`
-		GrantTypes                              []string      `json:"grantTypes"`
-		AuthenticationAttributes                []string      `json:"authenticationAttributes"`
-		TokenSigningAlgorithm                   string        `json:"tokenSigningAlgorithm"`
-		TokenEncryptionEnabled                  bool          `json:"tokenEncryptionEnabled"`
-		HashSalt                                string        `json:"hashSalt"`
-		ModuleMessageEnabledInPasswordGrant     bool          `json:"moduleMessageEnabledInPasswordGrant"`
-		TLSCertificateBoundAccessTokensEnabled  bool          `json:"tlsCertificateBoundAccessTokensEnabled"`
-		NbfClaimRequiredInRequestObject         bool          `json:"nbfClaimRequiredInRequestObject"`
-		DisplayNameAttribute                    string        `json:"displayNameAttribute"`
-		SupportedScopes                         []string      `json:"supportedScopes"`
-		ResponseTypeClasses                     []string      `json:"responseTypeClasses"`
-		ExpClaimRequiredInRequestObject         bool          `json:"expClaimRequiredInRequestObject"`
-		TokenCompressionEnabled                 bool          `json:"tokenCompressionEnabled"`
-		AllowedAudienceValues                   []interface{} `json:"allowedAudienceValues"`
-		TLSCertificateRevocationCheckingEnabled bool          `json:"tlsCertificateRevocationCheckingEnabled"`
+		TLSClientCertificateHeaderFormat              string        `json:"tlsClientCertificateHeaderFormat"`
+		SupportedSubjectTypes                         []string      `json:"supportedSubjectTypes"`
+		DefaultScopes                                 []interface{} `json:"defaultScopes"`
+		MacaroonTokenFormat                           string        `json:"macaroonTokenFormat"`
+		CodeVerifierEnforced                          string        `json:"codeVerifierEnforced"`
+		GrantTypes                                    []string      `json:"grantTypes"`
+		AuthenticationAttributes                      []string      `json:"authenticationAttributes"`
+		TokenSigningAlgorithm                         string        `json:"tokenSigningAlgorithm"`
+		TokenEncryptionEnabled                        bool          `json:"tokenEncryptionEnabled"`
+		HashSalt                                      string        `json:"hashSalt"`
+		ModuleMessageEnabledInPasswordGrant           bool          `json:"moduleMessageEnabledInPasswordGrant"`
+		TLSCertificateBoundAccessTokensEnabled        bool          `json:"tlsCertificateBoundAccessTokensEnabled"`
+		NbfClaimRequiredInRequestObject               bool          `json:"nbfClaimRequiredInRequestObject"`
+		MaxDifferenceBetweenRequestObjectNbfAndExp    int           `json:"maxDifferenceBetweenRequestObjectNbfAndExp"`
+		DisplayNameAttribute                          string        `json:"displayNameAttribute"`
+		SupportedScopes                               []string      `json:"supportedScopes"`
+		ResponseTypeClasses                           []string      `json:"responseTypeClasses"`
+		ExpClaimRequiredInRequestObject               bool          `json:"expClaimRequiredInRequestObject"`
+		TokenCompressionEnabled                       bool          `json:"tokenCompressionEnabled"`
+		AllowedAudienceValues                         []interface{} `json:"allowedAudienceValues"`
+		TLSCertificateRevocationCheckingEnabled       bool          `json:"tlsCertificateRevocationCheckingEnabled"`
 	}
 
 	CoreOIDCConfig struct {


### PR DESCRIPTION
Set the maxDifferenceBetweenRequestObjectNbfAndExp to 60 to pass FAPI Advanced Part 1 Conformance Tests

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/676