### PR TITLE
694: Configuring AM for tls_client_auth

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -10,6 +10,7 @@
     "issueRefreshToken": true
   },
   "advancedOAuth2Config": {
+    "tlsClientCertificateTrustedHeader": "{{.TLS.ClientCertHeaderName}}",
     "tlsClientCertificateHeaderFormat": "URLENCODED_PEM",
     "supportedSubjectTypes": [
       "public",

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -52,8 +52,6 @@ IDENTITY: # Root key for parameter values related with identity platform configu
     SECRET_MAPPINGS: # Map one or more secrets to the store
       SECRET_ID: am.services.oauth2.tls.client.cert.authentication
       ALIAS: oauth2-ob-ca-certs # name of the secret in google secrets manager
-
-
 USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_USERNAME: amadmin # Identity platform Username with admin grants (must exist previously)
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -43,6 +43,17 @@ IDENTITY: # Root key for parameter values related with identity platform configu
   REMOTE_CONSENT_ID: secure-open-banking-rcs # Identification of remote consent agent
   OBRI_SOFTWARE_PUBLISHER_AGENT_NAME: OBRI # software publisher agent name
   TEST_SOFTWARE_PUBLISHER_AGENT_NAME: test-publisher # test software publisher agent
+  GOOGLE_SECRET_STORES: # Configure one or more Google Secret Stores
+    NAME: Open Banking Trust Store
+    SERVICE_ACCOUNT: default
+    PROJECT: sbat-dev
+    SECRET_FORMAT: PEM
+    EXPIRY_DURATION_SECONDS: 1800
+    SECRET_MAPPINGS: # Map one or more secrets to the store
+      SECRET_ID: am.services.oauth2.tls.client.cert.authentication
+      ALIAS: oauth2-ob-ca-certs # name of the secret in google secrets manager
+
+
 USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_USERNAME: amadmin # Identity platform Username with admin grants (must exist previously)
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -46,4 +46,5 @@ IDENTITY: # Root key for parameter values related with identity platform configu
 USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_USERNAME: amadmin # Identity platform Username with admin grants (must exist previously)
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)
-
+TLS:
+  CLIENT_CERT_HEADER_NAME: ssl-client-cert # Name of the HTTP header that contains client's TLS cert. Note, nginx will set the cert into the ssl-client-cert header by default

--- a/main.go
+++ b/main.go
@@ -81,6 +81,9 @@ func main() {
 	fmt.Println("Attempting to configure AM Global Services Platform")
 	securebanking.ConfigureAmPlatformService(session.Cookie)
 
+	fmt.Println("Attempting to configure Google Secret Store(s)")
+	securebanking.ConfigureGoogleSecretStores(session.Cookie)
+
 	fmt.Println("Attempt PSD2 authentication trees initialization...")
 	securebanking.CreateSecureBankingPSD2AuthenticationTrees()
 	fmt.Println("Attempt to create secure banking remote consent...")

--- a/pkg/securebanking/crest_resource_creator.go
+++ b/pkg/securebanking/crest_resource_creator.go
@@ -24,29 +24,30 @@ func UpdateCrestResourceFromConfigFile(url string, configFileName string, cookie
 // config needs to be edited post unmarshalling e.g. to set an id value to that of a resource created in a previous step.
 func CreateOrUpdateCrestResourceFromConfigFile(httpMethod string, url string, configFileName string, cookie *http.Cookie) {
 	zap.L().Info("Attempting to create resource using CREST, url: " + url + ", configFileName: " + configFileName)
-
 	var jsonConfig map[string]interface{}
 	err := common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+configFileName, &common.Config, &jsonConfig)
 	if err != nil {
 		zap.S().Fatalw(fmt.Sprintf("Failed to log jsonConfig: %s , error: %v", configFileName, err))
 	}
+	CreateOrUpdateCrestResource(httpMethod, url, jsonConfig, cookie)
+}
 
+func CreateOrUpdateCrestResource(httpMethod string, url string, requestBody map[string]interface{}, cookie *http.Cookie) {
 	var responsePayload map[string]interface{}
 	resp, err := restClient.R().
 		SetHeader("Accept", "*/*").
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Connection", "keep-alive").
 		SetHeader("X-Requested-With", "XMLHttpRequest").
-		SetHeader("Accept-API-Version", "protocol=1.0,resource=1.0").
+		SetHeader("Accept-API-Version", "protocol=2.0,resource=1.0").
 		SetContentLength(true).
 		SetCookie(cookie).
-		SetBody(jsonConfig).
+		SetBody(requestBody).
 		SetResult(&responsePayload).
 		Execute(httpMethod, url)
 
-	zap.S().Info("resp is " + resp.String())
 	if resp != nil && resp.StatusCode() == 409 {
-		zap.S().Info("Nothing created, resource already exists for url: " + url + " , configFileName: " + configFileName)
+		zap.S().Info("Nothing created, resource already exists for url: " + url)
 	} else {
 		common.RaiseForStatus(err, resp.Error(), resp.StatusCode())
 		zap.S().Info("Created resource, _id: ", responsePayload["_id"])

--- a/pkg/securebanking/google_secret_stores.go
+++ b/pkg/securebanking/google_secret_stores.go
@@ -1,0 +1,68 @@
+package securebanking
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+	"net/http"
+	"net/url"
+	"secure-banking-uk-initializer/pkg/common"
+	"secure-banking-uk-initializer/pkg/types"
+)
+
+// ConfigureGoogleSecretStores Configures Google Secret Stores in AM if defined in the config
+//
+// This function processes the "GOOGLE_SECRET_STORES" config block, this is treated as an array and can
+// be used to create multiple stores.
+//
+// Once the store has been created then one or more secrets may be mapped to it using the "SECRET_MAPPINGS" config block
+// which is also treated as an array
+func ConfigureGoogleSecretStores(cookie *http.Cookie) {
+	stores := common.Config.Identity.GoogleSecretStores
+	if stores == nil || len(stores) == 0 {
+		zap.S().Infow("No Google Secret Stores found in config, nothing to do.")
+		return
+	}
+	for _, store := range stores {
+		configureGoogleSecretStore(store, cookie)
+		configSecretMappings(store, cookie)
+	}
+}
+
+func configureGoogleSecretStore(store types.GoogleSecretStore, cookie *http.Cookie) {
+	createStoreUrl, storeRequest := buildCreateStoreRequest(store)
+	zap.S().Infow("Attempting to configure Google Secret Store", "store", store,
+		"requestUrl", createStoreUrl, "requestJson", storeRequest)
+	CreateOrUpdateCrestResource("PUT", createStoreUrl, storeRequest, cookie)
+}
+
+func buildCreateStoreRequest(store types.GoogleSecretStore) (string, map[string]interface{}) {
+	requestBody := make(map[string]interface{})
+	requestBody["_id"] = store.Name
+	requestBody["serviceAccount"] = store.ServiceAccount
+	requestBody["project"] = store.Project
+	requestBody["expiryDurationSeconds"] = store.ExpiryDurationSeconds
+	requestBody["secretFormat"] = store.SecretFormat
+
+	createStoreUrl := fmt.Sprintf("https://%s/am/json/realms/root/realms/%s/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/%s",
+		common.Config.Hosts.IdentityPlatformFQDN, common.Config.Identity.AmRealm, url.PathEscape(store.Name))
+	return createStoreUrl, requestBody
+}
+
+func configSecretMappings(store types.GoogleSecretStore, cookie *http.Cookie) {
+	zap.S().Infow("Attempting to map secrets to store", "store", store)
+	for _, mapping := range store.SecretMappings {
+		createMappingUrl, mappingRequest := buildSecretMappingRequest(store.Name, mapping)
+		CreateOrUpdateCrestResource("PUT", createMappingUrl, mappingRequest, cookie)
+	}
+}
+
+func buildSecretMappingRequest(storeName string, secretMapping types.SecretMapping) (string, map[string]interface{}) {
+	createMappingUrl := fmt.Sprintf("https://%s/am/json/realms/root/realms/%s/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/%s/mappings/%s",
+		common.Config.Hosts.IdentityPlatformFQDN, common.Config.Identity.AmRealm, url.PathEscape(storeName), secretMapping.SecretId)
+
+	requestBody := make(map[string]interface{})
+	requestBody["secretId"] = secretMapping.SecretId
+	requestBody["aliases"] = []string{secretMapping.Alias}
+
+	return createMappingUrl, requestBody
+}

--- a/pkg/securebanking/google_secret_stores_test.go
+++ b/pkg/securebanking/google_secret_stores_test.go
@@ -1,0 +1,59 @@
+package securebanking
+
+import (
+	"github.com/stretchr/testify/assert"
+	"secure-banking-uk-initializer/pkg/common"
+	"secure-banking-uk-initializer/pkg/types"
+	"testing"
+)
+
+func configureGlobalConfig() {
+	common.Config.Hosts.IdentityPlatformFQDN = "testhost"
+	common.Config.Identity.AmRealm = "testrealm"
+}
+
+func Test_buildCreateStoreRequest(t *testing.T) {
+	configureGlobalConfig()
+
+	store := types.GoogleSecretStore{
+		Name:                  "Test Store",
+		ServiceAccount:        "test-acc",
+		Project:               "test-proj",
+		SecretFormat:          "PEM",
+		ExpiryDurationSeconds: 600,
+	}
+
+	actualRequestUrl, actualRequestBody := buildCreateStoreRequest(store)
+
+	expectedRequestUrl := "https://testhost/am/json/realms/root/realms/testrealm/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/Test%20Store"
+	expectedRequestBody := map[string]interface{}{
+		"_id":                   "Test Store",
+		"serviceAccount":        "test-acc",
+		"project":               "test-proj",
+		"expiryDurationSeconds": 600,
+		"secretFormat":          "PEM",
+	}
+
+	assert.Equalf(t, expectedRequestUrl, actualRequestUrl, "buildCreateStoreRequest(%v)", store)
+	assert.Equalf(t, expectedRequestBody, actualRequestBody, "buildCreateStoreRequest(%v)", store)
+}
+
+func Test_buildSecretMappingRequest(t *testing.T) {
+	configureGlobalConfig()
+
+	storeName := "Test Store"
+	secretMapping := types.SecretMapping{
+		SecretId: "am.services.oauth2.tls.client.cert.authentication",
+		Alias:    "a-secret-in-gsm",
+	}
+	actualRequestUrl, actualRequestBody := buildSecretMappingRequest(storeName, secretMapping)
+
+	expectedRequestUrl := "https://testhost/am/json/realms/root/realms/testrealm/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/Test%20Store/mappings/am.services.oauth2.tls.client.cert.authentication"
+	expectedRequestBody := map[string]interface{}{
+		"secretId": "am.services.oauth2.tls.client.cert.authentication",
+		"aliases":  []string{"a-secret-in-gsm"},
+	}
+
+	assert.Equalf(t, expectedRequestUrl, actualRequestUrl, "buildSecretMappingRequest(%v, %v)", storeName, secretMapping)
+	assert.Equalf(t, expectedRequestBody, actualRequestBody, "buildCreateStoreRequest(%v, %v)", storeName, secretMapping)
+}

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -26,16 +26,31 @@ type hosts struct {
 }
 
 type identity struct {
-	AmRealm                      string `mapstructure:"AM_REALM"`
-	IdmClientId                  string `mapstructure:"IDM_CLIENT_ID"`
-	IdmClientSecret              string `mapstructure:"IDM_CLIENT_SECRET"`
-	PolicyClientSecret           string `mapstructure:"POLICY_CLIENT_SECRET"`
-	RemoteConsentId              string `mapstructure:"REMOTE_CONSENT_ID"`
-	ObriSoftwarePublisherAgent   string `mapstructure:"OBRI_SOFTWARE_PUBLISHER_AGENT_NAME"`
-	TestSoftwarePublisherAgent   string `mapstructure:"TEST_SOFTWARE_PUBLISHER_AGENT_NAME"`
-	ServiceAccountPolicyUser     string `mapstructure:"SERVICE_ACCOUNT_POLICY_USER"`
-	ServiceAccountPolicyPassword string `mapstructure:"SERVICE_ACCOUNT_POLICY_PASSWORD"`
-	ServiceAccountPolicyEmail    string `mapstructure:"SERVICE_ACCOUNT_POLICY_EMAIL"`
+	AmRealm                      string              `mapstructure:"AM_REALM"`
+	IdmClientId                  string              `mapstructure:"IDM_CLIENT_ID"`
+	IdmClientSecret              string              `mapstructure:"IDM_CLIENT_SECRET"`
+	PolicyClientSecret           string              `mapstructure:"POLICY_CLIENT_SECRET"`
+	RemoteConsentId              string              `mapstructure:"REMOTE_CONSENT_ID"`
+	ObriSoftwarePublisherAgent   string              `mapstructure:"OBRI_SOFTWARE_PUBLISHER_AGENT_NAME"`
+	TestSoftwarePublisherAgent   string              `mapstructure:"TEST_SOFTWARE_PUBLISHER_AGENT_NAME"`
+	ServiceAccountPolicyUser     string              `mapstructure:"SERVICE_ACCOUNT_POLICY_USER"`
+	ServiceAccountPolicyPassword string              `mapstructure:"SERVICE_ACCOUNT_POLICY_PASSWORD"`
+	ServiceAccountPolicyEmail    string              `mapstructure:"SERVICE_ACCOUNT_POLICY_EMAIL"`
+	GoogleSecretStores           []GoogleSecretStore `mapstructure:"GOOGLE_SECRET_STORES"`
+}
+
+type GoogleSecretStore struct {
+	Name                  string          `mapstructure:"NAME"`
+	ServiceAccount        string          `mapstructure:"SERVICE_ACCOUNT"`
+	Project               string          `mapstructure:"PROJECT"`
+	SecretFormat          string          `mapstructure:"SECRET_FORMAT"`
+	ExpiryDurationSeconds int             `mapstructure:"EXPIRY_DURATION_SECONDS"`
+	SecretMappings        []SecretMapping `mapstructure:"SECRET_MAPPINGS"`
+}
+
+type SecretMapping struct {
+	SecretId string `mapstructure:"SECRET_ID"`
+	Alias    string `mapstructure:"ALIAS"`
 }
 
 type ig struct {

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -12,6 +12,7 @@ type Configuration struct {
 	Identity    identity    `mapstructure:"IDENTITY"`
 	Ig          ig          `mapstructure:"IG"`
 	Users       users       `mapstructure:"USERS"`
+	TLS         tls         `mapstructure:"TLS"`
 }
 
 type hosts struct {
@@ -63,4 +64,8 @@ type paths struct {
 type users struct {
 	FrPlatformAdminUsername string `mapstructure:"FR_PLATFORM_ADMIN_USERNAME"`
 	FrPlatformAdminPassword string `mapstructure:"FR_PLATFORM_ADMIN_PASSWORD"`
+}
+
+type tls struct {
+	ClientCertHeaderName string `mapstructure:"CLIENT_CERT_HEADER_NAME"`
 }

--- a/pkg/types/oauth2models.go
+++ b/pkg/types/oauth2models.go
@@ -35,27 +35,28 @@ type (
 	}
 
 	AdvancedOAuth2Config struct {
-		TLSClientCertificateHeaderFormat              string        `json:"tlsClientCertificateHeaderFormat"`
-		SupportedSubjectTypes                         []string      `json:"supportedSubjectTypes"`
-		DefaultScopes                                 []interface{} `json:"defaultScopes"`
-		MacaroonTokenFormat                           string        `json:"macaroonTokenFormat"`
-		CodeVerifierEnforced                          string        `json:"codeVerifierEnforced"`
-		GrantTypes                                    []string      `json:"grantTypes"`
-		AuthenticationAttributes                      []string      `json:"authenticationAttributes"`
-		TokenSigningAlgorithm                         string        `json:"tokenSigningAlgorithm"`
-		TokenEncryptionEnabled                        bool          `json:"tokenEncryptionEnabled"`
-		HashSalt                                      string        `json:"hashSalt"`
-		ModuleMessageEnabledInPasswordGrant           bool          `json:"moduleMessageEnabledInPasswordGrant"`
-		TLSCertificateBoundAccessTokensEnabled        bool          `json:"tlsCertificateBoundAccessTokensEnabled"`
-		NbfClaimRequiredInRequestObject               bool          `json:"nbfClaimRequiredInRequestObject"`
-		MaxDifferenceBetweenRequestObjectNbfAndExp    int           `json:"maxDifferenceBetweenRequestObjectNbfAndExp"`
-		DisplayNameAttribute                          string        `json:"displayNameAttribute"`
-		SupportedScopes                               []string      `json:"supportedScopes"`
-		ResponseTypeClasses                           []string      `json:"responseTypeClasses"`
-		ExpClaimRequiredInRequestObject               bool          `json:"expClaimRequiredInRequestObject"`
-		TokenCompressionEnabled                       bool          `json:"tokenCompressionEnabled"`
-		AllowedAudienceValues                         []interface{} `json:"allowedAudienceValues"`
-		TLSCertificateRevocationCheckingEnabled       bool          `json:"tlsCertificateRevocationCheckingEnabled"`
+		TlsClientCertificateTrustedHeader          string        `json:"tlsClientCertificateTrustedHeader"`
+		TLSClientCertificateHeaderFormat           string        `json:"tlsClientCertificateHeaderFormat"`
+		SupportedSubjectTypes                      []string      `json:"supportedSubjectTypes"`
+		DefaultScopes                              []interface{} `json:"defaultScopes"`
+		MacaroonTokenFormat                        string        `json:"macaroonTokenFormat"`
+		CodeVerifierEnforced                       string        `json:"codeVerifierEnforced"`
+		GrantTypes                                 []string      `json:"grantTypes"`
+		AuthenticationAttributes                   []string      `json:"authenticationAttributes"`
+		TokenSigningAlgorithm                      string        `json:"tokenSigningAlgorithm"`
+		TokenEncryptionEnabled                     bool          `json:"tokenEncryptionEnabled"`
+		HashSalt                                   string        `json:"hashSalt"`
+		ModuleMessageEnabledInPasswordGrant        bool          `json:"moduleMessageEnabledInPasswordGrant"`
+		TLSCertificateBoundAccessTokensEnabled     bool          `json:"tlsCertificateBoundAccessTokensEnabled"`
+		NbfClaimRequiredInRequestObject            bool          `json:"nbfClaimRequiredInRequestObject"`
+		MaxDifferenceBetweenRequestObjectNbfAndExp int           `json:"maxDifferenceBetweenRequestObjectNbfAndExp"`
+		DisplayNameAttribute                       string        `json:"displayNameAttribute"`
+		SupportedScopes                            []string      `json:"supportedScopes"`
+		ResponseTypeClasses                        []string      `json:"responseTypeClasses"`
+		ExpClaimRequiredInRequestObject            bool          `json:"expClaimRequiredInRequestObject"`
+		TokenCompressionEnabled                    bool          `json:"tokenCompressionEnabled"`
+		AllowedAudienceValues                      []interface{} `json:"allowedAudienceValues"`
+		TLSCertificateRevocationCheckingEnabled    bool          `json:"tlsCertificateRevocationCheckingEnabled"`
 	}
 
 	CoreOIDCConfig struct {


### PR DESCRIPTION
This change enables the OAuth2 Provider in AM to do tls_client_auth when TLS is being terminated by a service running in front of the AM instance, in this case by nginx. AM will inspect the configured header for the client's TLS cert and do the authentication checks based on this.

Configuring the Google Secrets Manager to store the trusted CA certs which auth requests will be tested against.

Summary of changes:

- Updating OAuth2 Provider configuration
  - Adding new viper config: "TLS.CLIENT_CERT_HEADER_NAME"
  - Setting the default configuration to use ssl-client-cert, this is the header that nginx uses to expose the client cert to downstream systems
- Configuring Google Secrets Manager in AM
  - Adding GOOGLE_SECRET_STORES block to the config, this describes the secret stores that we wish to create
  - Added google_secret_stores.go which processes the config and builds the CREST requests to create these stores and map secrets to them
  - If there is no config for GOOGLE_SECRET_STORES then the code does not try to configure any, for environments that use FIDC then this conf can be omitted as FIDC automatically provisions this store.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/694