### PR TITLE
fix FIDC Policy Service User Creation

### DIFF
--- a/pkg/securebanking/policy.go
+++ b/pkg/securebanking/policy.go
@@ -23,6 +23,10 @@ func CreatePolicyServiceUser() {
 	serviceUser := &types.ServiceUser{}
 	common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+"create-policy-service-user.json", &common.Config, serviceUser)
 	path := "/openidm/managed/user/?_action=create"
+	//FIDC IDM default user managed objects use a different naming pattern <realm>_user Eg:alpha_user
+	if common.Config.Environment.Type == "FIDC" {
+		path = "/openidm/managed/" + common.Config.Identity.AmRealm + "_user/?_action=create"
+	}
 	_, s := httprest.Client.Post(path, serviceUser, map[string]string{
 		"Accept":       "*/*",
 		"Content-Type": "application/json",


### PR DESCRIPTION
FIDC IDM default user managed objects use a different naming pattern <realm>_user Eg:alpha_user

To allow the creation of the SBAT Policy Service User we need to adapt the path so that it uses the configured realm name when targeting the managed object for user creation.