### PR TITLE
fix ig service user creation

### DIFF
--- a/pkg/identity-platform/platform.go
+++ b/pkg/identity-platform/platform.go
@@ -33,6 +33,10 @@ func CreateIGServiceUser() {
 		},
 	}
 	path := "/openidm/managed/user/?_action=create"
+	//FIDC IDM default user managed objects use a different naming pattern <realm>_user Eg:alpha_user
+	if common.Config.Environment.Type == "FIDC" {
+		path = "/openidm/managed/" + common.Config.Identity.AmRealm + "_user/?_action=create"
+	}
 	_, s := httprest.Client.Post(path, user, map[string]string{
 		"Accept":       "*/*",
 		"Content-Type": "application/json",


### PR DESCRIPTION
Same issue as for Policy Service User but for IG Service User.

FIDC IDM default user managed objects use a different naming pattern _user Eg:alpha_user

To allow the creation of the SBAT IG Service User we need to adapt the path so that it uses the configured realm name when targeting the managed object for user creation.

I have tested the change and the IG Service User is being created.

Checked in the application and also got this in the logs:

"caller":"identity-platform/platform.go:46","msg":"IG Service User","statusCode":201