### PR TITLE
304: Using IdentityPlatformFQDN in policy script

### DIFF
--- a/config/defaults/secure-open-banking/policy-evaluation-script.js
+++ b/config/defaults/secure-open-banking/policy-evaluation-script.js
@@ -2,7 +2,7 @@ function getIdmClientDetails() {
     return {
         "id": "{{ .Identity.IdmClientId }}",
         "secret": "{{ .Identity.IdmClientSecret }}",
-        "endpoint": "http://am/am/oauth2/realms/root/realms/{{ .Identity.AmRealm }}/access_token",
+        "endpoint": "https://{{ .Hosts.IdentityPlatformFQDN }}/am/oauth2/realms/root/realms/{{ .Identity.AmRealm }}/access_token",
         "scope": "fr:idm:*",
         "idmAdminUsername": "{{ .Ig.IgIdmUser }}",
         "idmAdminPassword": "{{ .Ig.IgIdmPassword }}"
@@ -222,7 +222,7 @@ function findIntentType(api) {
 function fetchIntentFromIdm(intentId, intentType) {
     var accessToken = getIdmAccessToken();
     var request = new org.forgerock.http.protocol.Request();
-    var uri ="http://idm/openidm/managed/" + intentType + "/" + intentId + "?_fields=_id,_rev,OBIntentObject,user/_id,accounts,apiClient/_id"
+    var uri ="https://{{ .Hosts.IdentityPlatformFQDN }}/openidm/managed/" + intentType + "/" + intentId + "?_fields=_id,_rev,OBIntentObject,user/_id,accounts,apiClient/_id"
 
     logger.message(script_name + ": IDM fetch " + uri)
 


### PR DESCRIPTION
When the policy script calls AM and IDM, it now uses the IDENTITY_PLATFORM_FQDN configuration and https.

This will work for both CDK and FIDC environments. The previous setup would only work for CDK (making use of CDK deployed k8s services)

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/304