### PR TITLE
718: Configure the realm default user authentication service

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -52,6 +52,12 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: RCS_UI_FQDN
+                - name: IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE
+                      optional: true
                 {{- if eq .Values.environment.fr_platform.type "FIDC" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -44,6 +44,7 @@ IDENTITY: # Root key for parameter values related with identity platform configu
   REMOTE_CONSENT_ID: secure-open-banking-rcs # Identification of remote consent agent
   OBRI_SOFTWARE_PUBLISHER_AGENT_NAME: OBRI # software publisher agent name
   TEST_SOFTWARE_PUBLISHER_AGENT_NAME: test-publisher # test software publisher agent
+  DEFAULT_USER_AUTHENTICATION_SERVICE: ldapService # configure the default user authentication service to use. ldapService should be used for CDK environments only.
 #  Example Google Secrets Configuration, uncomment once: https://github.com/SecureApiGateway/SecureApiGateway/issues/703 is completed
 #  GOOGLE_SECRET_STORES: # Configure one or more Google Secret Stores
 #    NAME: Open Banking Trust Store
@@ -55,8 +56,6 @@ IDENTITY: # Root key for parameter values related with identity platform configu
 #      SECRET_ID: am.services.oauth2.tls.client.cert.authentication
 #      ALIAS: oauth2-ob-ca-certs # name of the secret in google secrets manager
 #
-#  Configure the default user authentication service to use. This configuration is optional, it should be provided for FIDC environments.
-#  DEFAULT_USER_AUTHENTICATION_SERVICE: PasswordGrant
 USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_USERNAME: amadmin # Identity platform Username with admin grants (must exist previously)
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -54,6 +54,9 @@ IDENTITY: # Root key for parameter values related with identity platform configu
 #    SECRET_MAPPINGS: # Map one or more secrets to the store
 #      SECRET_ID: am.services.oauth2.tls.client.cert.authentication
 #      ALIAS: oauth2-ob-ca-certs # name of the secret in google secrets manager
+#
+#  Configure the default user authentication service to use. This configuration is optional, it should be provided for FIDC environments.
+#  DEFAULT_USER_AUTHENTICATION_SERVICE: PasswordGrant
 USERS: # Root key users to be created or to authenticate and authorize flows
   FR_PLATFORM_ADMIN_USERNAME: amadmin # Identity platform Username with admin grants (must exist previously)
   FR_PLATFORM_ADMIN_PASSWORD: replace-me # Identity platform User password with admin grants (must exist previously)

--- a/main.go
+++ b/main.go
@@ -83,6 +83,9 @@ func main() {
 		securebanking.ConfigureAmPlatformService(session.Cookie)
 	}
 
+	fmt.Println("Attempting to configure Realm Default User Authentication Service")
+	securebanking.ConfigureRealmDefaultUserAuthenticationService()
+
 	fmt.Println("Attempting to configure Google Secret Store(s)")
 	securebanking.ConfigureGoogleSecretStores(session.Cookie)
 

--- a/pkg/securebanking/authentication_config.go
+++ b/pkg/securebanking/authentication_config.go
@@ -133,3 +133,36 @@ func createPSD2SecureCustomerAuthenticationTree() {
 
 	zap.S().Infow("PSD2SecureCustomerAuthentication tree", "statusCode", status)
 }
+
+// ConfigureRealmDefaultUserAuthenticationService
+// This configures the default user authentication service to use for a particular realm. This service is used as the
+// fallback auth service when a more specific service isn't configured/specified.
+//
+// This is driven off the IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE configuration value
+//
+// For FIDC environments: this configuration is mandatory and will cause the program to exit if it is missing.
+// For CDK environments: configuring this is optional, the CDK comes preconfigured with a sensible default.
+func ConfigureRealmDefaultUserAuthenticationService() {
+	if common.Config.Identity.DefaultUserAuthenticationService == "" {
+		if common.Config.Environment.Type != "FIDC" {
+			zap.L().Info("No DefaultUserAuthenticationService configuration found, nothing to do")
+			return
+		} else {
+			panic("Configuration: DEFAULT_USER_AUTHENTICATION_SERVICE is required for FIDC environments")
+		}
+	}
+
+	zap.S().Infow("Configuring Default Authentication Service for realm",
+		"realm", common.Config.Identity.AmRealm, "authService", common.Config.Identity.DefaultUserAuthenticationService)
+	path := "/am/json/realms/root/realms/" + common.Config.Identity.AmRealm + "/realm-config/authentication"
+
+	status := httprest.Client.Put(path, map[string]string{
+		"orgConfig": common.Config.Identity.DefaultUserAuthenticationService,
+	}, map[string]string{
+		"Accept":             "application/json",
+		"Content-Type":       "application/json",
+		"Accept-Api-Version": "protocol=2.0, resource=1.0",
+	})
+
+	zap.S().Infow("Configure Default Authentication Service response", "statusCode", status)
+}

--- a/pkg/securebanking/authentication_config.go
+++ b/pkg/securebanking/authentication_config.go
@@ -138,18 +138,11 @@ func createPSD2SecureCustomerAuthenticationTree() {
 // This configures the default user authentication service to use for a particular realm. This service is used as the
 // fallback auth service when a more specific service isn't configured/specified.
 //
-// This is driven off the IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE configuration value
-//
-// For FIDC environments: this configuration is mandatory and will cause the program to exit if it is missing.
-// For CDK environments: configuring this is optional, the CDK comes preconfigured with a sensible default.
+// This is driven off the IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE configuration value, the program will exit with
+// an error if the configuration is missing.
 func ConfigureRealmDefaultUserAuthenticationService() {
 	if common.Config.Identity.DefaultUserAuthenticationService == "" {
-		if common.Config.Environment.Type != "FIDC" {
-			zap.L().Info("No DefaultUserAuthenticationService configuration found, nothing to do")
-			return
-		} else {
-			panic("Configuration: DEFAULT_USER_AUTHENTICATION_SERVICE is required for FIDC environments")
-		}
+		panic("Configuration: DEFAULT_USER_AUTHENTICATION_SERVICE is required")
 	}
 
 	zap.S().Infow("Configuring Default Authentication Service for realm",

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -26,17 +26,18 @@ type hosts struct {
 }
 
 type identity struct {
-	AmRealm                      string              `mapstructure:"AM_REALM"`
-	IdmClientId                  string              `mapstructure:"IDM_CLIENT_ID"`
-	IdmClientSecret              string              `mapstructure:"IDM_CLIENT_SECRET"`
-	PolicyClientSecret           string              `mapstructure:"POLICY_CLIENT_SECRET"`
-	RemoteConsentId              string              `mapstructure:"REMOTE_CONSENT_ID"`
-	ObriSoftwarePublisherAgent   string              `mapstructure:"OBRI_SOFTWARE_PUBLISHER_AGENT_NAME"`
-	TestSoftwarePublisherAgent   string              `mapstructure:"TEST_SOFTWARE_PUBLISHER_AGENT_NAME"`
-	ServiceAccountPolicyUser     string              `mapstructure:"SERVICE_ACCOUNT_POLICY_USER"`
-	ServiceAccountPolicyPassword string              `mapstructure:"SERVICE_ACCOUNT_POLICY_PASSWORD"`
-	ServiceAccountPolicyEmail    string              `mapstructure:"SERVICE_ACCOUNT_POLICY_EMAIL"`
-	GoogleSecretStores           []GoogleSecretStore `mapstructure:"GOOGLE_SECRET_STORES"`
+	AmRealm                          string              `mapstructure:"AM_REALM"`
+	IdmClientId                      string              `mapstructure:"IDM_CLIENT_ID"`
+	IdmClientSecret                  string              `mapstructure:"IDM_CLIENT_SECRET"`
+	PolicyClientSecret               string              `mapstructure:"POLICY_CLIENT_SECRET"`
+	RemoteConsentId                  string              `mapstructure:"REMOTE_CONSENT_ID"`
+	ObriSoftwarePublisherAgent       string              `mapstructure:"OBRI_SOFTWARE_PUBLISHER_AGENT_NAME"`
+	TestSoftwarePublisherAgent       string              `mapstructure:"TEST_SOFTWARE_PUBLISHER_AGENT_NAME"`
+	ServiceAccountPolicyUser         string              `mapstructure:"SERVICE_ACCOUNT_POLICY_USER"`
+	ServiceAccountPolicyPassword     string              `mapstructure:"SERVICE_ACCOUNT_POLICY_PASSWORD"`
+	ServiceAccountPolicyEmail        string              `mapstructure:"SERVICE_ACCOUNT_POLICY_EMAIL"`
+	GoogleSecretStores               []GoogleSecretStore `mapstructure:"GOOGLE_SECRET_STORES"`
+	DefaultUserAuthenticationService string              `mapstructure:"DEFAULT_USER_AUTHENTICATION_SERVICE"`
 }
 
 type GoogleSecretStore struct {


### PR DESCRIPTION
- Adding new configuration item: IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE
  - Updated the default viper configuration to set `ldapService` which is the default for CDK environments 
- Adding function to configure the realm default user auth service using this config value
- Created PR to override the configuration to `PasswordGrant` for the nightly environment which is a FIDC deployment.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/718