### PR TITLE
720 - Slack notification when PR complete

### DIFF
--- a/.github/workflows/slackNotification.yml
+++ b/.github/workflows/slackNotification.yml
@@ -1,0 +1,18 @@
+name: Check Changes
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Push Slack Notification
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        if: success()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.WEBHOOK_SBAT_DEV_SLACK }}
+          SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
New github action workflow which will trigger when there is a push to master, push to master is only possible when a PR is complete so does the same result as a merge being closed

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/720