### PR TITLE
694: Configure GoogleSecretStore for CDK environments only.

### DIFF
--- a/.config-git-ref
+++ b/.config-git-ref
@@ -1,1 +1,1 @@
-cb0a154e964bccd9b98a4f185e0afaf33c6cbdff
+972fb360bc500ebee92b5155b407f3eabaf44d29

--- a/.config-git-ref
+++ b/.config-git-ref
@@ -1,1 +1,1 @@
-e99bfc44ff4d66e70eef1be61363887d383a8aa7
+cb0a154e964bccd9b98a4f185e0afaf33c6cbdff

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -58,6 +58,12 @@ spec:
                       name: securebanking-platform-config
                       key: IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE
                       optional: true
+                - name: IDENTITY.GOOGLE_SECRET_STORES.NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: IDENTITY_GOOGLE_SECRET_STORES_NAME
+                      optional: true
                 {{- if eq .Values.environment.fr_platform.type "FIDC" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD
                   valueFrom:

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -58,11 +58,17 @@ spec:
                       name: securebanking-platform-config
                       key: IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE
                       optional: true
-                - name: IDENTITY.GOOGLE_SECRET_STORES.NAME
+                - name: IDENTITY.GOOGLE_SECRET_STORES_NAME
                   valueFrom:
                     configMapKeyRef:
                       name: securebanking-platform-config
-                      key: IDENTITY_GOOGLE_SECRET_STORES_NAME
+                      key: IDENTITY_GOOGLE_SECRET_STORE_NAME
+                      optional: true
+                - name: IDENTITY.GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: IDENTITY_GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME
                       optional: true
                 {{- if eq .Values.environment.fr_platform.type "FIDC" }}
                 - name: USERS.FR_PLATFORM_ADMIN_PASSWORD

--- a/main.go
+++ b/main.go
@@ -86,8 +86,8 @@ func main() {
 	fmt.Println("Attempting to configure Realm Default User Authentication Service")
 	securebanking.ConfigureRealmDefaultUserAuthenticationService()
 
-	fmt.Println("Attempting to configure Google Secret Store(s)")
-	securebanking.ConfigureGoogleSecretStores(session.Cookie)
+	fmt.Println("Attempting to configure Google Secret Store")
+	securebanking.ConfigureGoogleSecretStore(session.Cookie)
 
 	fmt.Println("Attempt PSD2 authentication trees initialization...")
 	securebanking.CreateSecureBankingPSD2AuthenticationTrees()

--- a/pkg/securebanking/google_secret_stores.go
+++ b/pkg/securebanking/google_secret_stores.go
@@ -23,7 +23,10 @@ func ConfigureGoogleSecretStores(cookie *http.Cookie) {
 		return
 	}
 	for _, store := range stores {
-		configureGoogleSecretStore(store, cookie)
+		// FIDC environments come with pre-existing GoogleSecretStore which cannot be edited, only map secrets in this case
+		if common.Config.Environment.Type != "FIDC" {
+			configureGoogleSecretStore(store, cookie)
+		}
 		configSecretMappings(store, cookie)
 	}
 }

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -26,32 +26,20 @@ type hosts struct {
 }
 
 type identity struct {
-	AmRealm                          string              `mapstructure:"AM_REALM"`
-	IdmClientId                      string              `mapstructure:"IDM_CLIENT_ID"`
-	IdmClientSecret                  string              `mapstructure:"IDM_CLIENT_SECRET"`
-	PolicyClientSecret               string              `mapstructure:"POLICY_CLIENT_SECRET"`
-	RemoteConsentId                  string              `mapstructure:"REMOTE_CONSENT_ID"`
-	ObriSoftwarePublisherAgent       string              `mapstructure:"OBRI_SOFTWARE_PUBLISHER_AGENT_NAME"`
-	TestSoftwarePublisherAgent       string              `mapstructure:"TEST_SOFTWARE_PUBLISHER_AGENT_NAME"`
-	ServiceAccountPolicyUser         string              `mapstructure:"SERVICE_ACCOUNT_POLICY_USER"`
-	ServiceAccountPolicyPassword     string              `mapstructure:"SERVICE_ACCOUNT_POLICY_PASSWORD"`
-	ServiceAccountPolicyEmail        string              `mapstructure:"SERVICE_ACCOUNT_POLICY_EMAIL"`
-	GoogleSecretStores               []GoogleSecretStore `mapstructure:"GOOGLE_SECRET_STORES"`
-	DefaultUserAuthenticationService string              `mapstructure:"DEFAULT_USER_AUTHENTICATION_SERVICE"`
-}
-
-type GoogleSecretStore struct {
-	Name                  string          `mapstructure:"NAME"`
-	ServiceAccount        string          `mapstructure:"SERVICE_ACCOUNT"`
-	Project               string          `mapstructure:"PROJECT"`
-	SecretFormat          string          `mapstructure:"SECRET_FORMAT"`
-	ExpiryDurationSeconds int             `mapstructure:"EXPIRY_DURATION_SECONDS"`
-	SecretMappings        []SecretMapping `mapstructure:"SECRET_MAPPINGS"`
-}
-
-type SecretMapping struct {
-	SecretId string `mapstructure:"SECRET_ID"`
-	Alias    string `mapstructure:"ALIAS"`
+	AmRealm                                  string `mapstructure:"AM_REALM"`
+	IdmClientId                              string `mapstructure:"IDM_CLIENT_ID"`
+	IdmClientSecret                          string `mapstructure:"IDM_CLIENT_SECRET"`
+	PolicyClientSecret                       string `mapstructure:"POLICY_CLIENT_SECRET"`
+	RemoteConsentId                          string `mapstructure:"REMOTE_CONSENT_ID"`
+	ObriSoftwarePublisherAgent               string `mapstructure:"OBRI_SOFTWARE_PUBLISHER_AGENT_NAME"`
+	TestSoftwarePublisherAgent               string `mapstructure:"TEST_SOFTWARE_PUBLISHER_AGENT_NAME"`
+	ServiceAccountPolicyUser                 string `mapstructure:"SERVICE_ACCOUNT_POLICY_USER"`
+	ServiceAccountPolicyPassword             string `mapstructure:"SERVICE_ACCOUNT_POLICY_PASSWORD"`
+	ServiceAccountPolicyEmail                string `mapstructure:"SERVICE_ACCOUNT_POLICY_EMAIL"`
+	GoogleSecretStoreName                    string `mapstructure:"GOOGLE_SECRET_STORE_NAME"`
+	GoogleSecretStoreProject                 string `mapstructure:"GOOGLE_SECRET_STORE_PROJECT"`
+	GoogleSecretStoreOAuth2CaCertsSecretName string `mapstructure:"GOOGLE_SECRET_STORE_OAUTH2_CA_CERTS_SECRET_NAME"`
+	DefaultUserAuthenticationService         string `mapstructure:"DEFAULT_USER_AUTHENTICATION_SERVICE"`
 }
 
 type ig struct {

--- a/pkg/types/secrets.go
+++ b/pkg/types/secrets.go
@@ -1,0 +1,16 @@
+package types
+
+// GoogleSecretStore represents a secret store in AM which is backed by Google Secrets Manager
+type GoogleSecretStore struct {
+	Name                  string
+	ServiceAccount        string
+	Project               string
+	SecretFormat          string
+	ExpiryDurationSeconds int
+}
+
+// SecretMapping maps an AM SecredId to a secret alias, for GoogleSecretStore this alias is the secret name in Secrets Manager
+type SecretMapping struct {
+	SecretId string
+	Alias    string
+}


### PR DESCRIPTION
Refactoring to only support creating a single Google Secret Store, there is no use case for needing multiple and FIDC environments only allow a single one.

Changing the logic to only create the secret store for CDK environments, as FIDC come pre-configured with a secret store which cannot be modified.

For CDK & FIDC envs, mapping secrets to the store is supported. Currently only: `am.services.oauth2.tls.client.cert.authentication` can be mapped.

https://github.com/SecureApiGateway/SecureApiGateway/issues/694
