### PR TITLE
694: Fix typo in env var name: IDENTITY.GOOGLE_SECRET_STORE_NAME

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -58,7 +58,7 @@ spec:
                       name: securebanking-platform-config
                       key: IDENTITY_DEFAULT_USER_AUTHENTICATION_SERVICE
                       optional: true
-                - name: IDENTITY.GOOGLE_SECRET_STORES_NAME
+                - name: IDENTITY.GOOGLE_SECRET_STORE_NAME
                   valueFrom:
                     configMapKeyRef:
                       name: securebanking-platform-config


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/694