### PR TITLE
793: Removing reference to RCS_UI_FQDN config map key, as it is now not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ There are a variables used before load the configuration file and these variable
 | `HOSTS.IG_FQDN`                | obdemo.dev.forgerock.financial | Ig Full Qualified Domain Name                |
 | `HOSTS.RCS_FQDN`               | rcs.dev.forgerock.financial    | RSC Full Qualified Domain Name               |
 | `HOSTS.RS_FQDN`                | rs.dev.forgerock.financial     | RS Full Qualified Domain Name                |
-| `HOSTS.RCS_UI_FQDN`            | rcs-ui.dev.forgerock.financial | RCS UI Full Qualified Domain Name            |
 | `HOSTS.SCHEME`                 | https                          | URI scheme, Syntax part of a generic URI     |
 </details>
 

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -47,11 +47,6 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: IDENTITY_PLATFORM_FQDN
-                - name: HOSTS.RCS_UI_FQDN
-                  valueFrom:
-                    configMapKeyRef:
-                      name: securebanking-platform-config
-                      key: RCS_UI_FQDN
                 - name: IDENTITY.DEFAULT_USER_AUTHENTICATION_SERVICE
                   valueFrom:
                     configMapKeyRef:

--- a/pkg/types/configuration.go
+++ b/pkg/types/configuration.go
@@ -18,7 +18,6 @@ type Configuration struct {
 type hosts struct {
 	BaseFQDN             string   `mapstructure:"BASE_FQDN"`
 	WildcardFQDN         string   `mapstructure:"WILDCARD_FQDN"`
-	RcsUiFQDN            string   `mapstructure:"RCS_UI_FQDN"`
 	IgFQDN               string   `mapstructure:"IG_FQDN"`
 	IdentityPlatformFQDN string   `mapstructure:"IDENTITY_PLATFORM_FQDN"`
 	Scheme               string   `mapstructure:"SCHEME"`


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/793