### PR TITLE
784: Updating helm chart to make use of the IG_ secrets defined in openig-secrets-env secret

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -98,6 +98,36 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: RCS_CONSENT_RESPONSE_JWT_ISSUER
+                - name: IG.IG_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_CLIENT_ID
+                - name: IG.IG_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_CLIENT_SECRET
+                - name: IG.IG_IDM_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_IDM_USER
+                - name: IG.IG_IDM_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_IDM_PASSWORD
+                - name: IG.IG_AGENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_AGENT_ID
+                - name: IG.IG_AGENT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: openig-secrets-env
+                      key: IG_AGENT_PASSWORD
               command: [ "/bin/sh", "-c" ]
               args:
                 - |


### PR DESCRIPTION
The values were previously not being configured, we were relying on the default values in the viper config to match those in the configmap. The values have now been migrated to secrets, these secrets are being mounted as env vars and are updating the viper config.

In future, if we wish to change the secret values i.e. randomly generate them, IG and the Initializer will now use consistent values.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/784